### PR TITLE
Fix #9

### DIFF
--- a/src/dactyl_keyboard/dactyl.clj
+++ b/src/dactyl_keyboard/dactyl.clj
@@ -46,10 +46,10 @@
 ;;   http://patentimages.storage.googleapis.com/EP0219944A2/imgf0002.png
 ;; Fixed-z overrides the z portion of the column ofsets above.
 ;; NOTE: THIS DOESN'T WORK QUITE LIKE I'D HOPED.
-; (def fixed-angles [(deg2rad 10) (deg2rad 10) 0 0 0 (deg2rad -15) (deg2rad -15)])
-; (def fixed-x [-41.5 -22.5 0 20.3 41.4 65.5 89.6])  ; relative to the middle finger
-; (def fixed-z [12.1    8.3 0  5   10.7 14.5 17.5])
-; (def fixed-tenting (deg2rad 0))
+ (def fixed-angles [(deg2rad 10) (deg2rad 10) 0 0 0 (deg2rad -15) (deg2rad -15)])
+ (def fixed-x [-41.5 -22.5 0 20.3 41.4 65.5 89.6])  ; relative to the middle finger
+ (def fixed-z [12.1    8.3 0  5   10.7 14.5 17.5])
+ (def fixed-tenting (deg2rad 0))
 
 ;;;;;;;;;;;;;;;;;;;;;;;
 ;; General variables ;;


### PR DESCRIPTION
Seems to fix the bug, running `echo '(load-file "src/dactyl_keyboard/dactyl.clj")' | docker run -i -v $(pwd -P):/data -w /data clojure` now gives:

```
dactyl-keyboard.dactyl=> (load-file "src/dactyl_keyboard/dactyl.clj")
#'dactyl-keyboard.dactyl/-main
dactyl-keyboard.dactyl=> Bye for now!
```